### PR TITLE
띠 계산기 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@
 
 ### Reference
 - https://docs.python.org/ko/3.10/library/datetime.html
+#### 다음은 띠계산기
+

--- a/api/index.py
+++ b/api/index.py
@@ -32,7 +32,7 @@ def age_calculator(birthday: str) -> Dict[str, str]:
     
     return {
             "birthday": birthday,
-            "age": str(age) + str(agezod)
+            "age": str(age) + str(agezod),
 	    #"띠": agezod
             #"만나이": str(man_age),
             "basedate": str(today),

--- a/api/index.py
+++ b/api/index.py
@@ -21,8 +21,14 @@ def age_calculator(birthday: str) -> Dict[str, str]:
     today = date.today()
     birth_date = datetime.strptime(birthday, "%Y-%m-%d").date()
     age = today.year - birth_date.year
-    zod = ["원숭이띠","닭띠","개띠","돼지띠","쥐띠","소띠","호랑이띠","토끼띠","용띠","뱀띠","말","양"]
-    agezod = zod[int(birth_date.year)%12]
+    zod = ["🐒 Monkey 원숭이띠","🐓 Rooster 닭띠","🐕 Dog 개띠","🐖 Pig 돼지띠","🐀 Rat 쥐띠","🐂 Ox 소띠","🐅 Tiger 호랑이띠","🐇 Rabbit 토끼띠","🐉 Dragon 용띠","🐍 Snake 뱀띠","🐎 Horse 말띠","🐐 Goat 양띠"]
+    
+    if birth_date.month == 1 or (birth_date.month == 2 and birth_date.day < 4):
+        zod_year = birth_date.year-1
+    else:
+        zod_year = birth_date.year
+    agezod = zod[int(zod_year)%12]
+    
     if (today.month,today.day)>=(birth_date.month,birth_date.day):
         age = age
         bday_chek = "네"
@@ -32,7 +38,7 @@ def age_calculator(birthday: str) -> Dict[str, str]:
     
     return {
             "birthday": birthday,
-            "age": f"{age}살 (당신의 띠는: {agezod})",
+            "age": f"{age}살   -   당신의 띠는: {agezod}",
 	    #"띠": agezod
             #"만나이": str(man_age),
             "basedate": str(today),

--- a/api/index.py
+++ b/api/index.py
@@ -21,8 +21,8 @@ def age_calculator(birthday: str) -> Dict[str, str]:
     today = date.today()
     birth_date = datetime.strptime(birthday, "%Y-%m-%d").date()
     age = today.year - birth_date.year
-    zod=["말띠","양띠","원숭이띠","닭띠","개띠","돼지띠","쥐띠","소띠","호랑이띠","토끼띠","용띠","뱀띠"]
-    agezod=zod[int(birth_date.year)%12]
+    zod = ["말띠","양띠","원숭이띠","닭띠","개띠","돼지띠","쥐띠","소띠","호랑이띠","토끼띠","용띠","뱀띠"]
+    agezod = zod[int(birth_date.year)%12]
     if (today.month,today.day)>=(birth_date.month,birth_date.day):
         age = age
         bday_chek = "네"
@@ -32,10 +32,10 @@ def age_calculator(birthday: str) -> Dict[str, str]:
     
     return {
             "birthday": birthday,
-            "age": str(age)+ str(agezod)
+            "age": str(age) + str(agezod)
 	    #"띠": agezod
             #"만나이": str(man_age),
             "basedate": str(today),
-            "생일이 지났습니까?": bday_chek ,
+            #"생일이 지났습니까?": bday_chek ,
             "message": "Age calculated successfully!"
             }

--- a/api/index.py
+++ b/api/index.py
@@ -32,8 +32,8 @@ def age_calculator(birthday: str) -> Dict[str, str]:
     
     return {
             "birthday": birthday,
-            "age": str(age),
-	    "띠": agezod
+            "age": str(age)+ str(agezod)
+	    #"띠": agezod
             #"만나이": str(man_age),
             "basedate": str(today),
             "생일이 지났습니까?": bday_chek ,

--- a/api/index.py
+++ b/api/index.py
@@ -21,6 +21,8 @@ def age_calculator(birthday: str) -> Dict[str, str]:
     today = date.today()
     birth_date = datetime.strptime(birthday, "%Y-%m-%d").date()
     age = today.year - birth_date.year
+    zod=["말띠","양띠","원숭이띠","닭띠","개띠","돼지띠","쥐띠","소띠","호랑이띠","토끼띠","용띠","뱀띠"]
+    agezod=zod[int(birth_date.year)%12]
     if (today.month,today.day)>=(birth_date.month,birth_date.day):
         age = age
         bday_chek = "네"
@@ -31,6 +33,7 @@ def age_calculator(birthday: str) -> Dict[str, str]:
     return {
             "birthday": birthday,
             "age": str(age),
+	    "띠": agezod
             #"만나이": str(man_age),
             "basedate": str(today),
             "생일이 지났습니까?": bday_chek ,

--- a/api/index.py
+++ b/api/index.py
@@ -21,7 +21,7 @@ def age_calculator(birthday: str) -> Dict[str, str]:
     today = date.today()
     birth_date = datetime.strptime(birthday, "%Y-%m-%d").date()
     age = today.year - birth_date.year
-    zod = ["말띠","양띠","원숭이띠","닭띠","개띠","돼지띠","쥐띠","소띠","호랑이띠","토끼띠","용띠","뱀띠"]
+    zod = ["원숭이띠","닭띠","개띠","돼지띠","쥐띠","소띠","호랑이띠","토끼띠","용띠","뱀띠","말","양"]
     agezod = zod[int(birth_date.year)%12]
     if (today.month,today.day)>=(birth_date.month,birth_date.day):
         age = age

--- a/api/index.py
+++ b/api/index.py
@@ -32,7 +32,7 @@ def age_calculator(birthday: str) -> Dict[str, str]:
     
     return {
             "birthday": birthday,
-            "age": str(age) + str(agezod),
+            "age": f"{age}살 (당신의 띠는: {agezod})",
 	    #"띠": agezod
             #"만나이": str(man_age),
             "basedate": str(today),


### PR DESCRIPTION
# 요구사항
- ~~12 간지를 태양력에 대충 맞춰 출력한다.~~
- 12 간지를 음력에 맞춰서 출력한다.

# 테스트 시나리오
- [x] 2000년 1월 1일생 (생일 지남)   출력:25살 토끼띠
- [x] 2000년 2월 3일생 (생일 안지남)   출력 24살 토끼띠
- [x] 2000년 2월 4일생 (생일 안지남)   출력:24살 용띠
- [x] 2001년 1월 1일생 (생일 지남)      출력:24살 용띠
- [x] 2001년 2월 3일생 (생일 안지남)    출력:23살 용띠
- [x] 2001년 2월 4일생 (생일 안지남)   출력:23살 뱀

# 제약조건
- ~~띠는 음력이지만 태양력으로 1월 1일 부터 띠를 반영함~~
- (최초 음력 무시 태양력으로만 구성하였으나 음력 반영으로 현실에 맞게 추가함)

# 음력 반영 띠 출력 구현
- 양력 2월 4일 기준(입춘)으로  구분한다는 것을 확인. (예를 들어 2월 3일생 까지는 작년 2월 4일 이 후 태어난 친구들과 띠가 같음.)
- 생년월일 중 월이 1월생 이거나 2월 그리고 4일 이전이 생일 이라면 띠 계산식에서 -1 계산하여 보정함

# 참고코드

- 띠 리스트
zodiac_animals = [
    "🐀 Rat",      # 자 - 쥐
    "🐂 Ox",       # 축 - 소
    "🐅 Tiger",    # 인 - 호랑이
    "🐇 Rabbit",   # 묘 - 토끼
    "🐉 Dragon",   # 진 - 용
    "🐍 Snake",    # 사 - 뱀
    "🐎 Horse",    # 오 - 말
    "🐐 Goat",     # 미 - 양
    "🐒 Monkey",   # 신 - 원숭이
    "🐓 Rooster",  # 유 - 닭
    "🐕 Dog",      # 술 - 개
    "🐖 Pig"       # 해 - 돼지
]
 
# 수정사항
- 음력 반영 띠 계산 로직 추가: 음력 반영하여 출생일 에 따른 띠 구분 출력, 띠 출력 시에 그림 추가 기능 수정
- 수정5: "당신의 띠는: "<= 추가
- 수정4: 띠 순서 오류 수정
- 수정3: 출력단 "," 누락 수정
- 수정2: 리스트 인덱스 호출 명령에서 integer 로 수정