### PR TITLE
Vercel OS 종류 및 버전 확인

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -64,6 +64,7 @@ def age_calculator(birthday: str) -> Dict[str, str]:
             "kage": f"한국나이는 {kage}살 입니다",
             "speaker":f"발표자는 : {speaker} 입니다",
 	    "zodiac": agezod,
+	    "os-name": get_os_pretty_name(),
             "python version": sver,
  	    #"만나이": str(man_age),
             "basedate": str(today),
@@ -71,3 +72,11 @@ def age_calculator(birthday: str) -> Dict[str, str]:
             "message": "Age calculated successfully!"
 
             }
+
+
+def get_os_pretty_name():
+          with open('/etc/os-release','r') as file:
+                  for line in file:
+                          if line.startswith('PRETTY_NAME'):
+                                  return line.split("=")[1].strip().strip('"')
+          return None

--- a/api/index.py
+++ b/api/index.py
@@ -56,7 +56,8 @@ def age_calculator(birthday: str) -> Dict[str, str]:
     else:
         age = age - 1
         bday_chek = "아니요"
-    
+
+
     return {
             "birthday": birthday,
             "age": f"{age}살 , 연나이는 : {yage}살,  한국나이는 : {kage}살,  당신의 띠는 : {agezod},  발표자는 : {speaker} 입니다 / 이 서버의 python version : {pver} 입니다 ",
@@ -65,7 +66,11 @@ def age_calculator(birthday: str) -> Dict[str, str]:
             "speaker":f"발표자는 : {speaker} 입니다",
 	    "zodiac": agezod,
 	    "os-name": get_os_pretty_name(),
+	    "osv-name": read_os_release(),
             "python version": sver,
+            "psys": system,
+            "preles": release,
+            "pvers": version,
  	    #"만나이": str(man_age),
             "basedate": str(today),
             #"bdaypass": bday_chek ,
@@ -74,9 +79,26 @@ def age_calculator(birthday: str) -> Dict[str, str]:
             }
 
 
+system, release, version = platform.system_alias(platform.system(), platform.release(), platform.version())
+
 def get_os_pretty_name():
           with open('/etc/os-release','r') as file:
                   for line in file:
                           if line.startswith('PRETTY_NAME'):
                                   return line.split("=")[1].strip().strip('"')
           return None
+
+def read_os_release():
+    try:
+        with open("/etc/os-release", "r") as k:
+            os_release_info = {}
+            for line in k:
+                key, _, value = line.partition("=")
+                os_release_info[key] = value.strip().strip('"')
+
+        os_name = os_release_info.get("NAME", "Unknown")
+        os_version = os_release_info.get("VERSION", "Unknown")
+        result = str(os_name)+str(os_version)
+        return result
+    except FileNotFoundError:
+        return {"Error": "No /etc/os-release file found"}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextjs-fastapi",
-  "version": "0.4.0",
+  "version": "0.5.2",
   "private": true,
   "scripts": {
     "fastapi-dev": "pip3 install -r requirements.txt && python3 -m uvicorn api.index:app --reload",


### PR DESCRIPTION
- [x] vercel 의 os 버전을 출력해보자
- [x] - cat /etc/os-relese 이 명령어도 파이썬에서 작동할까?


## 작업계획
- 파이썬에서 리눅스 명령어 실행 방법에 대한 리서치
- 위에서 찾은 방법을 중심으로 공식 가이들르 찾아서 읽어보가
- 로컬 환경에 적용해서 우분투 24.xx.xx 이 나오는지 확인
- 나온다면 push 한다음 branch 가 vercel 에 배포되게 해서 잘 되는지 확인
- 릴리스 노트 작성

# 구현
 ## 1. os-release 정보를 읽어와서 PRETTY_NAME 의 값을 출력하는 방법
    def get_os_pretty_name():
             with open('/etc/os-release','r') as file:
                     for line in file:
                             if line.startswith('PRETTY_NAME'):
                                     return line.split("=")[1].strip().strip('"')
          return None

## 2. 같은 방법이지만 다른코드 ( 딕셔너리로 저장 후 필요한 값을 반복문을 통해서 편집 저장 ,값이 없는 경우 Unknown 으로 반환) 
 def read_os_release():
     try:
         with open("/etc/os-release", "r") as k:
             os_release_info = {}
             for line in k:
                 key, _, value = line.partition("=")
                 os_release_info[key] = value.strip().strip('"')

         os_name = os_release_info.get("NAME", "Unknown")
         os_version = os_release_info.get("VERSION", "Unknown")
         result = str(os_name)+str(os_version)
         return result
    except FileNotFoundError:
        return {"Error": "No /etc/os-release file found"}

##  3. platform 
system, release, version = platform.system_alias(platform.system(), platform.release(), platform.version())

# API 테스트 결과 
![ver](https://github.com/user-attachments/assets/57cbc749-570e-4352-9b1e-ef246f41d8fc)

